### PR TITLE
refactor: remove processing overlay from CameraOverlayView

### DIFF
--- a/Aripe/Features/Camera/Views/CameraOverlayView.swift
+++ b/Aripe/Features/Camera/Views/CameraOverlayView.swift
@@ -45,11 +45,6 @@ struct CameraOverlayView: View {
                     )
                     .padding(.bottom, 130)
                 
-                // Processing overlay
-                if viewModel.isProcessing {
-                    processingOverlay
-                }
-                
                 VStack {
                     //MARK: Top Bar
                     HStack() {
@@ -70,6 +65,7 @@ struct CameraOverlayView: View {
                                     )
                                 )
                         }
+                        .disabled(viewModel.isProcessing)
                         .padding(25)
                     }
                     Spacer()
@@ -110,12 +106,6 @@ struct CameraOverlayView: View {
                                 Circle()
                                     .fill(viewModel.isProcessing ? Color.gray : Color.aPrimaryGreen)
                                     .frame(width: 65, height: 65)
-                                
-                                if viewModel.isProcessing {
-                                    ProgressView()
-                                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                                        .scaleEffect(0.8)
-                                }
                             }
                         }
                         .disabled(viewModel.isProcessing)
@@ -164,28 +154,8 @@ struct CameraOverlayView: View {
             }
         }
     }
-    
-    private var processingOverlay: some View {
-        ZStack {
-            Color.black.opacity(0.3)
-            
-            VStack(spacing: 16) {
-                ProgressView()
-                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                    .scaleEffect(1.5)
-                
-                Text("Processing...")
-                    .foregroundColor(.white)
-                    .font(.headline)
-            }
-            .padding(24)
-            .background(Color.black.opacity(0.8))
-            .cornerRadius(12)
-        }
-    }
 }
 
 #Preview {
     CameraOverlayView(viewModel: CameraViewModel())
 }
-

--- a/Aripe/Features/Summary/Views/SummaryView.swift
+++ b/Aripe/Features/Summary/Views/SummaryView.swift
@@ -117,10 +117,8 @@ struct SummaryView: View {
                 .background(.aPrimaryGreen)
                 .cornerRadius(12)
         }
-        .disabled(!viewModel.isPredictionValid)
         .padding(.horizontal, 16)
-    }
-}
+    }}
 
 // MARK: - Previews with Sample Data
 #Preview("Ripe Apple") {


### PR DESCRIPTION
This pull request refactors the `CameraOverlayView` and `SummaryView` components in the `Aripe` project to simplify their code by removing redundant elements and improving user interaction. The most significant changes include the removal of the `processingOverlay` view and related logic from `CameraOverlayView` and adjustments to button states in both components.

### Refactoring of `CameraOverlayView`:

* Removed the `processingOverlay` view and its associated logic, simplifying the overlay structure. This includes eliminating the conditional rendering of `ProgressView` and the "Processing..." text. [[1]](diffhunk://#diff-746edc3b842e2d7954835cd1df23faf3c2caf13b7d9f78151f3545bcee9e489eL48-L52) [[2]](diffhunk://#diff-746edc3b842e2d7954835cd1df23faf3c2caf13b7d9f78151f3545bcee9e489eL113-L118) [[3]](diffhunk://#diff-746edc3b842e2d7954835cd1df23faf3c2caf13b7d9f78151f3545bcee9e489eL167-L191)
* Added `.disabled(viewModel.isProcessing)` to relevant UI elements to ensure buttons are disabled during processing, improving user experience.

### Adjustment in `SummaryView`:

* Removed the `.disabled(!viewModel.isPredictionValid)` modifier from the button, potentially altering its interaction logic.